### PR TITLE
remember which objects were created

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,10 @@ const adapter = new utils.Adapter({
         if (adapter.config.forceinit) {
             adapter.getAdapterObjects((res) => {
                 for (const id of Object.keys(res)) {
+                    if (/^rpi2\.\d+$/.test(id)) {
+                        adapter.log.debug('Skip root object ' + id);
+                        continue;
+                    }
                     adapter.log.debug('Remove ' + id + ': ' + id);
 
                     adapter.delObject(id, (res, err) => {

--- a/main.js
+++ b/main.js
@@ -16,11 +16,8 @@ const adapter = new utils.Adapter({
         config = adapter.config;
 
         if (adapter.config.forceinit) {
-            adapter.objects.getObjectList({startkey: adapter.name + '.' + adapter.instance, endkey: adapter.name + '.' + adapter.instance + '\u9999'}, function (err, res) {
-                res = res.rows;
-                for (let i = 0; i < res.length; i++) {
-                    const id = res[i].doc.common.name;
-
+            adapter.getAdapterObjects((res) => {
+                for (const id of Objects.keys(res)) {
                     adapter.log.debug('Remove ' + id + ': ' + id);
 
                     adapter.delObject(id, (res, err) => {
@@ -33,18 +30,19 @@ const adapter = new utils.Adapter({
                     });
                 }
             });
+            objects = {}; //all objects are deleted.
+        } else {
+             adapter.getAdapterObjects((res) => {
+                objects = {};
+                for (const id of Object.keys(res)) {
+                    objects[id] = true; //object already exists.
+                }
+
+                adapter.log.debug('received all objects');
+                main();
+             });
         }
         adapter.subscribeStates('*');
-
-        adapter.getAdapterObjects((res) => {
-            objects = {};
-            for (const id of Object.keys(res)) {
-                objects[id] = true; //object already exists.
-            }
-
-            adapter.log.debug('received all objects');
-            main();
-        });
     },
     stateChange: function (id, state) {
         adapter.log.debug('stateChange for ' + id + ' found state = ' + JSON.stringify(state));

--- a/main.js
+++ b/main.js
@@ -17,15 +17,15 @@ const adapter = new utils.Adapter({
 
         if (adapter.config.forceinit) {
             adapter.getAdapterObjects((res) => {
-                for (const id of Objects.keys(res)) {
+                for (const id of Object.keys(res)) {
                     adapter.log.debug('Remove ' + id + ': ' + id);
 
                     adapter.delObject(id, (res, err) => {
-                        if (res !== undefined && res !== 'Not exists') adapter.log.error('res from delObject: ' + res);
+                        if (res !== undefined && res !== null && res !== 'Not exists') adapter.log.error('res from delObject: ' + res);
                         if (err !== undefined) adapter.log.error('err from delObject: ' + err);
                     });
                     adapter.deleteState(id, (res, err) => {
-                        if (res !== undefined && res !== 'Not exists') adapter.log.error('res from deleteState: ' + res);
+                        if (res !== undefined && res !== null && res !== 'Not exists') adapter.log.error('res from deleteState: ' + res);
                         if (err !== undefined) adapter.log.error('err from deleteState: ' + err);
                     });
                 }

--- a/main.js
+++ b/main.js
@@ -39,10 +39,11 @@ const adapter = new utils.Adapter({
                 }
 
                 adapter.log.debug('received all objects');
-                main();
              });
         }
         adapter.subscribeStates('*');
+        
+        main();
     },
     stateChange: function (id, state) {
         adapter.log.debug('stateChange for ' + id + ' found state = ' + JSON.stringify(state));

--- a/main.js
+++ b/main.js
@@ -14,6 +14,7 @@ const adapter = new utils.Adapter({
 
     ready: function () {
         config = adapter.config;
+        objects = {};
 
         if (adapter.config.forceinit) {
             adapter.getAdapterObjects((res) => {
@@ -34,10 +35,8 @@ const adapter = new utils.Adapter({
                     });
                 }
             });
-            objects = {}; //all objects are deleted.
         } else {
              adapter.getAdapterObjects((res) => {
-                objects = {};
                 for (const id of Object.keys(res)) {
                     objects[id] = true; //object already exists.
                 }

--- a/main.js
+++ b/main.js
@@ -36,11 +36,10 @@ const adapter = new utils.Adapter({
         }
         adapter.subscribeStates('*');
 
-        adapter.objects.getObjectList({include_docs: true}, (err, res) => {
-            res = res.rows;
+        adapter.getAdapterObjects((res) => {
             objects = {};
-            for (let i = 0; i < res.length; i++) {
-                objects[res[i].doc._id] = res[i].doc;
+            for (const id of Object.keys(res)) {
+                objects[id] = true; //object already exists.
             }
 
             adapter.log.debug('received all objects');
@@ -220,6 +219,7 @@ function parser() {
                 };
 
                 adapter.extendObject(c, stateObj);
+                objects[c] = true; //remember that we created the object.
             }
             const o = config[c];
             for (const i in o) {
@@ -268,6 +268,7 @@ function parser() {
                                 _id: objectName
                             };
                             adapter.extendObject(objectName, stateObj);
+                            objects[objectName] = true; //remember that we created the object.
                         }
                         adapter.setState(objectName, {
                             val: value,
@@ -312,6 +313,7 @@ function parser() {
                                 _id: objectName
                             };
                             adapter.extendObject(objectName, stateObj);
+                            objects[objectName] = true; //remember that we created the object.
                         }
                         adapter.setState(objectName, {
                             val: value,


### PR DESCRIPTION
the old code got a list of ALL objects (i.e. not rpi2 only) just to check if states/devices are already created. That is a bit of overkill (especially memory wise). On the other hand it did not remember if a state/device was created during runtime, the object list was only updated on startup. 

Now it maintains a map that only stores "true" for all objects created (in previous executions or during runtime) -> sufficient for the check if a device/object needs to be created.

This fixes #15 

//Edit: 
Extended the PR to remove the other call to adapter.objects.getObjectList ( See ioBroker/ioBroker.js-controller#359 ) and make both loops similar, again.

Would make #11 obsolete.