### PR TITLE
cpuinfo_cur_freq read only Fix

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -179,7 +179,11 @@
         "interval": 60000,
         "cpu": {
             "cpu_frequency": {
-                "command": "cat /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq",
+                "command": "test -r /sys/devices/system/cpu/cpufreq/policy0/cpuinfo_cur_freq "+
+                             "&& cat /sys/devices/system/cpu/cpufreq/policy0/cpuinfo_cur_freq "+
+                             "|| test -r /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq "+
+                                  "&& cat /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq "+
+                                  "|| echo -1000",
                 "regexp": "(.*)",
                 "post": "$1/1000"
             },

--- a/io-package.json
+++ b/io-package.json
@@ -179,11 +179,7 @@
         "interval": 60000,
         "cpu": {
             "cpu_frequency": {
-                "command": "test -r /sys/devices/system/cpu/cpufreq/policy0/cpuinfo_cur_freq "+
-                             "&& cat /sys/devices/system/cpu/cpufreq/policy0/cpuinfo_cur_freq "+
-                             "|| test -r /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq "+
-                                  "&& cat /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq "+
-                                  "|| echo -1000",
+                "command": "test -r /sys/devices/system/cpu/cpufreq/policy0/cpuinfo_cur_freq && cat /sys/devices/system/cpu/cpufreq/policy0/cpuinfo_cur_freq || test -r /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq && cat /sys/devices/system/cpu/cpufreq/policy0/scaling_cur_freq || echo -1000",
                 "regexp": "(.*)",
                 "post": "$1/1000"
             },


### PR DESCRIPTION
Umstellung des Befehls zum Lesen der CPU Frequenz nach Folgedem Muster:
- Schauen ob cpuinfo_cur_freq lesbar ist. Wenn ja => Datei auslesen, wert in kHz zurück geben
- Wenn nein: Schauen ob scaling_cur_freq lesbar ist. Wenn ja => Datei auslesen, Wert in kHz zurück geben
Ansonsten -1 kHz zurück geben (Als eindeutigen Fehlerwert)

-> Issue #17 