### PR TITLE
Update gpioControl.js

### DIFF
--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -8,6 +8,7 @@ const exec = util.promisify(require('node:child_process').exec);
 
 function getRaspberryModelFromCpuInfo(cpuinfo) {
     if ((cpuinfo).includes("Zero")){
+                this.log.debug('Using GPIO chip 0 for Raspberry Pi Zero family.');
                     return 1;
                 }
     else{

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -8,7 +8,8 @@ const exec = util.promisify(require('node:child_process').exec);
 
 function getRaspberryModelFromCpuInfo(cpuinfo) {
     // RPi Zero familiy has a different naming. All Rpi Zero share the same ChipNum as RPi 1 and thus can all be handled as a Rpi 1.
-    if (cpuinfo[1].includes("Zero")){
+    this.log.debug('Parsing RPi Model');
+    if (cpuinfo.includes("Zero")){
                 this.log.debug('Identify as Raspberry Pi 1 for Raspberry Pi Zero family compatibility.');
                     return 1;
                 }

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -8,7 +8,7 @@ const exec = util.promisify(require('node:child_process').exec);
 
 function getRaspberryModelFromCpuInfo(cpuinfo) {
     if ((cpuinfo).includes("Zero")){
-                this.log.debug('Using GPIO chip 0 for Raspberry Pi Zero family.');
+                this.log.debug('Identify as Raspberry Pi 1 for Raspberry Pi Zero family compatibility.');
                     return 1;
                 }
     else{

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -66,7 +66,7 @@ class GpioControl {
                 }
             } catch (e) {
                 this.log.error('Cannot read CPU Info: ' + e);
-                this.log.warm('Defaulting to Chip Num 0 for Rpi Zero 2 (W)')
+                this.log.warn('Defaulting to Chip Num 0 for Rpi Zero 2 (W)')
                 chipNum = 0;
             }
             this.gpioChip = true; //let's keep this condition for now.

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -7,6 +7,7 @@ const util = require('util');
 const exec = util.promisify(require('node:child_process').exec);
 
 function getRaspberryModelFromCpuInfo(cpuinfo) {
+    //RPi Zero familiy has a different naming. All Rpi Zero share the same ChipNum as RPi 1 and thus can all be handled as a Rpi 1.
     if ((cpuinfo).includes("Zero")){
                 this.log.debug('Identify as Raspberry Pi 1 for Raspberry Pi Zero family compatibility.');
                     return 1;

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -73,7 +73,6 @@ class GpioControl {
                 this.log.error('Cannot read CPU Info: ' + e);
             }
 
-
             //this.log.debug(Input);
             //this.log.debug(Output);
 

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -8,7 +8,7 @@ const exec = util.promisify(require('node:child_process').exec);
 
 function getRaspberryModelFromCpuInfo(cpuinfo) {
     // RPi Zero familiy has a different naming. All Rpi Zero share the same ChipNum as RPi 1 and thus can all be handled as a Rpi 1.
-    if ((cpuinfo).includes("Zero")){
+    if (cpuinfo.includes("Zero")){
                 this.log.debug('Identify as Raspberry Pi 1 for Raspberry Pi Zero family compatibility.');
                     return 1;
                 }

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -8,14 +8,14 @@ const exec = util.promisify(require('node:child_process').exec);
 
 function getRaspberryModelFromCpuInfo(cpuinfo) {
     // RPi Zero familiy has a different naming. All Rpi Zero share the same ChipNum as RPi 1 and thus can all be handled as a Rpi 1.
-    if (cpuinfo.includes("Zero")){
-                    return 1;
-                }
-    else{
-    const modelRegEx = /^Raspberry Pi (\d+) Model.*/mi;
-    const model = modelRegEx.exec(cpuinfo)[1];
-    return Number(model);
-}
+    if (cpuinfo.includes("Zero")) {
+        return 1;
+    }
+    else {
+        const modelRegEx = /^Raspberry Pi (\d+) Model.*/mi;
+        const model = modelRegEx.exec(cpuinfo)[1];
+        return Number(model);
+    }
 }
 
 // not used.. classes are too overengineered... :-(
@@ -57,22 +57,22 @@ class GpioControl {
             let chipNum = null;
             try {
                 this.log.debug(Default);
-                const {stdout, stderr} = await exec('cat /proc/device-tree/model');
+                const { stdout, stderr } = await exec('cat /proc/device-tree/model');
                 this.log.debug('CPU Info: ' + stdout);
                 this.log.debug('STDERR: ' + stderr);
                 const model = getRaspberryModelFromCpuInfo(stdout);
                 this.log.debug(`Got ${model} from ${stdout}.`);
-                    if (model >= 5) {
+                if (model >= 5) {
                     this.log.debug('Using GPIO chip 4 for Raspberry Pi 5 or newer.');
                     chipNum = 4;
-                    } else {
-                        chipNum = 0;
-                        }
+                } else {
+                    chipNum = 0;
+                }
                 this.gpioChip = true; //let's keep this condition for now. 
             } catch (e) {
                 this.log.error('Cannot read CPU Info: ' + e);
-               }
-            
+            }
+
 
             //this.log.debug(Input);
             //this.log.debug(Output);

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -48,7 +48,7 @@ class GpioControl {
 
         try {
             const { Default, Edge } = require('opengpio');
-            let chipNum = 0;
+            let chipNum = null;
             try {
                 this.log.debug(Default);
 
@@ -61,10 +61,15 @@ class GpioControl {
                     this.log.debug('Using GPIO chip 4 for Raspberry Pi 5 or newer.');
                     chipNum = 4;
                 }
-                this.gpioChip = true; //let's keep this condition for now.
+                else {
+                chipNum = 0;
+                }
             } catch (e) {
                 this.log.error('Cannot read CPU Info: ' + e);
+                this.log.warm('Defaulting to Chip Num 0 for Rpi Zero 2 (W)')
+                chipNum = 0;
             }
+            this.gpioChip = true; //let's keep this condition for now.
 
             //this.log.debug(Input);
             //this.log.debug(Output);

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -67,7 +67,7 @@ class GpioControl {
                         }
                 }
                 catch {
-                if (stdout).includes("Zero"){
+                if ((stdout).includes("Zero")){
                     this.log.debug('Using GPIO chip 0 for Raspberry Zero family.');
                     chipNum = 0;
                 }

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -8,9 +8,7 @@ const exec = util.promisify(require('node:child_process').exec);
 
 function getRaspberryModelFromCpuInfo(cpuinfo) {
     // RPi Zero familiy has a different naming. All Rpi Zero share the same ChipNum as RPi 1 and thus can all be handled as a Rpi 1.
-    this.log.debug('Parsing RPi Model');
     if (cpuinfo.includes("Zero")){
-                this.log.debug('Identify as Raspberry Pi 1 for Raspberry Pi Zero family compatibility.');
                     return 1;
                 }
     else{

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -7,7 +7,7 @@ const util = require('util');
 const exec = util.promisify(require('node:child_process').exec);
 
 function getRaspberryModelFromCpuInfo(cpuinfo) {
-    //RPi Zero familiy has a different naming. All Rpi Zero share the same ChipNum as RPi 1 and thus can all be handled as a Rpi 1.
+    // RPi Zero familiy has a different naming. All Rpi Zero share the same ChipNum as RPi 1 and thus can all be handled as a Rpi 1.
     if ((cpuinfo).includes("Zero")){
                 this.log.debug('Identify as Raspberry Pi 1 for Raspberry Pi Zero family compatibility.');
                     return 1;
@@ -56,6 +56,7 @@ class GpioControl {
         try {
             const { Default, Edge } = require('opengpio');
             let chipNum = null;
+            try {
                 this.log.debug(Default);
                 const {stdout, stderr} = await exec('cat /proc/device-tree/model');
                 this.log.debug('CPU Info: ' + stdout);
@@ -65,8 +66,7 @@ class GpioControl {
                     if (model >= 5) {
                     this.log.debug('Using GPIO chip 4 for Raspberry Pi 5 or newer.');
                     chipNum = 4;
-                    }
-                    else {
+                    } else {
                         chipNum = 0;
                         }
                 this.gpioChip = true; //let's keep this condition for now. 

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -7,9 +7,14 @@ const util = require('util');
 const exec = util.promisify(require('node:child_process').exec);
 
 function getRaspberryModelFromCpuInfo(cpuinfo) {
+    if ((cpuinfo).includes("Zero")){
+                    return 1;
+                }
+    else{
     const modelRegEx = /^Raspberry Pi (\d+) Model.*/mi;
     const model = modelRegEx.exec(cpuinfo)[1];
     return Number(model);
+}
 }
 
 // not used.. classes are too overengineered... :-(
@@ -49,9 +54,7 @@ class GpioControl {
         try {
             const { Default, Edge } = require('opengpio');
             let chipNum = null;
-            try {
                 this.log.debug(Default);
-
                 const {stdout, stderr} = await exec('cat /proc/device-tree/model');
                 this.log.debug('CPU Info: ' + stdout);
                 this.log.debug('STDERR: ' + stderr);
@@ -65,15 +68,9 @@ class GpioControl {
                     else {
                         chipNum = 0;
                         }
+                this.gpioChip = true; //let's keep this condition for now. 
                 }
-                catch {
-                if ((stdout).includes("Zero")){
-                    this.log.debug('Using GPIO chip 0 for Raspberry Zero family.');
-                    chipNum = 0;
-                }
-                }
-               this.gpioChip = true; //let's keep this condition for now. 
-            } catch (e) {
+             } catch (e) {
                 this.log.error('Cannot read CPU Info: ' + e);
                }
             

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -55,21 +55,28 @@ class GpioControl {
                 const {stdout, stderr} = await exec('cat /proc/device-tree/model');
                 this.log.debug('CPU Info: ' + stdout);
                 this.log.debug('STDERR: ' + stderr);
+                try {
                 const model = getRaspberryModelFromCpuInfo(stdout);
                 this.log.debug(`Got ${model} from ${stdout}.`);
-                if (model >= 5) {
+                    if (model >= 5) {
                     this.log.debug('Using GPIO chip 4 for Raspberry Pi 5 or newer.');
                     chipNum = 4;
+                    }
+                    else {
+                        chipNum = 0;
+                        }
                 }
-                else {
-                chipNum = 0;
+                catch {
+                if (stdout).includes("Zero"){
+                    this.log.debug('Using GPIO chip 0 for Raspberry Zero family.');
+                    chipNum = 0;
                 }
+                }
+               this.gpioChip = true; //let's keep this condition for now. 
             } catch (e) {
                 this.log.error('Cannot read CPU Info: ' + e);
-                this.log.warn('Defaulting to Chip Num 0 for Rpi Zero 2 (W)')
-                chipNum = 0;
-            }
-            this.gpioChip = true; //let's keep this condition for now.
+               }
+            
 
             //this.log.debug(Input);
             //this.log.debug(Output);

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -8,7 +8,7 @@ const exec = util.promisify(require('node:child_process').exec);
 
 function getRaspberryModelFromCpuInfo(cpuinfo) {
     // RPi Zero familiy has a different naming. All Rpi Zero share the same ChipNum as RPi 1 and thus can all be handled as a Rpi 1.
-    if (cpuinfo.includes("Zero")){
+    if (cpuinfo[1].includes("Zero")){
                 this.log.debug('Identify as Raspberry Pi 1 for Raspberry Pi Zero family compatibility.');
                     return 1;
                 }

--- a/lib/gpioControl.js
+++ b/lib/gpioControl.js
@@ -60,7 +60,6 @@ class GpioControl {
                 const {stdout, stderr} = await exec('cat /proc/device-tree/model');
                 this.log.debug('CPU Info: ' + stdout);
                 this.log.debug('STDERR: ' + stderr);
-                try {
                 const model = getRaspberryModelFromCpuInfo(stdout);
                 this.log.debug(`Got ${model} from ${stdout}.`);
                     if (model >= 5) {
@@ -71,8 +70,7 @@ class GpioControl {
                         chipNum = 0;
                         }
                 this.gpioChip = true; //let's keep this condition for now. 
-                }
-             } catch (e) {
+            } catch (e) {
                 this.log.error('Cannot read CPU Info: ' + e);
                }
             


### PR DESCRIPTION
Raspberry Pi Zero / Zero 2 CPU Description has another format and cannot be parsed the same way like Raspberry Pi 3,4 and 5. However all of these use the same chipNum (0). So let's just assume we are using one of these models in case the parsing fails