### PR TITLE
Check if /boot is nonempty before evaluating sdcard_boot objects

### DIFF
--- a/lib/parsers.json
+++ b/lib/parsers.json
@@ -71,7 +71,7 @@
       "multiline": true
     },
     "sdcard_boot_total": {
-      "command": "df /boot/*",
+      "command": "test -n \"$(ls /boot)\" && df /boot/*",
       "regexp": "\\S+\\s+(\\d+).*\\/boot",
       "post": "$1/1024",
       "multiline": true
@@ -83,7 +83,7 @@
       "multiline": true
     },
     "sdcard_boot_used": {
-      "command": "df /boot/*",
+      "command": "test -n \"$(ls /boot)\" && df /boot/*",
       "regexp": "\\S+\\s+\\d+\\s+(\\d+).*\\/boot",
       "post": "$1/1024",
       "multiline": true


### PR DESCRIPTION
Closes #245 

If iobroker runs in a container, then the /boot folder is empty. This leads to error "df: '/boot/*': No such file or directory" in logs.