### PR TITLE
Update parsers.json

### DIFF
--- a/lib/parsers.json
+++ b/lib/parsers.json
@@ -109,6 +109,13 @@
       "regexp": "(.*)",
       "post": "$1/1000",
       "role": "value.temperature"
+    },
+    "nvme_temp": {
+       "command": "test -e /usr/sbin/nvme && sudo nvme smart-log /dev/nvme0 || echo \"0\"",
+       "regexp": "temperature\\s+:\\s+(\\d+)",
+       "post": "%1",
+       "role": "value.temperature",
+       "multiline": true
     }
   },
   "uptime": {


### PR DESCRIPTION
Add NVME temperature to measurements

Tested on RPI5 with one nvme ssd and on an RPI4 without nvme SSD.

Note: The measurement requires the package nvme-cli to be installed and the command `nvme smart-log /dev/nvme0` to be added to the sudoer subsystem for execution without password.

If the package is not installed, the value for the NVME temperature will be 0. If the command is not added to the sudoer subsystem the adapter will throw an error when trying to read the temperature.

Unfortunately, I found no alternative to read the nvme temperature as a normal user.

A.